### PR TITLE
Disable deployment to silence CI failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ deploy:
   email: chingor@google.com # To satisfy the CLA check, replace this with bot email.
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   on:
+    repo: census-instrumentation/opencensus-ruby
     branch: master


### PR DESCRIPTION
There's still a [master CI failure](https://travis-ci.com/wantedly/opencensus-ruby/jobs/163184216) due to deploy failure; as this fork doesn't need the pages deployment now, we can just turn it off in repositories other than the upstream.